### PR TITLE
Add PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GlueMegara
 
-This visualization tool for the MEGARA multi-spectrograph (https://guaix.fis.ucm.es/megara) has been developed with the Glue viewer, since this offers the possibility of defining custom code functions and including them in the file called 'data_viewer.py'. The process has been accomplished at the Universidad Complutense de Madrid in order to create an extensible tool in Python for the analysis of data obtained with MEGARA.
+[![PyPI version](https://badge.fury.io/py/megara-visual-glue.svg)](https://badge.fury.io/py/megara-visual-glue)
+
+This visualization tool for the MEGARA multi-spectrograph (https://guaix.fis.ucm.es/megara) has been developed with the Glue viewer (https://glueviz.org/), since this offers the possibility of defining custom code functions and including them in the file called `data_viewer.py`. The process has been accomplished at the Universidad Complutense de Madrid in order to create an extensible tool in Python for the analysis of data obtained with MEGARA.
 
 


### PR DESCRIPTION
This adds a small badge in README.md, linking to PyPI. It's common in Python projects (see, for example https://github.com/astropy/astropy)